### PR TITLE
Adding FilledInterpolation

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -12,6 +12,7 @@ import Base:
 
 export
     Interpolation,
+    FilledInterpolation,
     Constant,
     Linear,
     Quadratic,
@@ -257,5 +258,26 @@ stagedfunction prefilter{TWeights,TCoefs,N,IT<:Quadratic}(::Type{TWeights}, A::A
 end
 
 nindexes(N::Int) = N == 1 ? "1 index" : "$N indexes"
+
+type FilledInterpolation{T}
+    fillvalue
+    itp::Interpolation{T}
+end
+FilledInterpolation(fillvalue, itpargs...) = FilledInterpolation(fillvalue, Interpolation(itpargs...))
+
+function getindex(fitp::FilledInterpolation, args...)
+    n = length(args)
+    N = ndims(fitp.itp)
+    n == N || return error("Must index $(N)-dimensional interpolation objects with $(nindexes(N))")
+
+    for i = 1:length(args)
+        if args[i] < 1 || args[i] > size(fitp.itp, i)
+            #In the extrapolation region
+            return fitp.fillvalue
+        end
+    end
+    #In the interpolation region
+    return getindex(fitp.itp,args...)
+end
 
 end # module


### PR DESCRIPTION
A FilledInterpolation type is proposed which provides capabilities for a user-defined value to be used for filling the extrapolation domain of an Interpolation.  The FilledInterpolation type includes an Interpolation object that is constructed with any existing ExtrapolationBehavior.  The ExtrapolationBehavior of the Interpolation object is replaced with the user-defined fillvalue in the extrapolation region of the FilledInterpolation.

The approach taken for this functionality was proposed to me by @tlycken in response to my email inquiries about adding functionality similar to the use of an "extrapval" argument in Matlab's interp1/interp2/interpn functions and the fill_value keyword in scipy.interpolate's interp1d/interp2d/interpn functions.
